### PR TITLE
Fix module name to allow be deployed using Buildroot

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,18 @@
 .PHONY: all rockspec build install-test clean
 
 VERSION = 1.1.1
-NAME = protobuf-$(VERSION)-0
+NAME = protobuf-lua-$(VERSION)-0
 
 all: build
 
 rockspec:
-	sed "s/%VERSION%/$(VERSION)/g" protobuf.rockspec.tmpl > protobuf-$(VERSION)-0.rockspec
+	sed "s/%VERSION%/$(VERSION)/g" protobuf-lua.rockspec.tmpl > protobuf-lua-$(VERSION)-0.rockspec
 
 build: rockspec
-	luarocks pack protobuf-$(VERSION)-0.rockspec
+	luarocks pack protobuf-lua-$(VERSION)-0.rockspec
 
 install-test: build
-	luarocks --tree=tree install protobuf-1.1.1-0.src.rock
+	luarocks --tree=tree install protobuf-lua-1.1.1-0.src.rock
 
 clean:
 	rm -rf *.rockspec *.rock src/pb.o src/pb.so tree

--- a/protobuf-lua.rockspec.tmpl
+++ b/protobuf-lua.rockspec.tmpl
@@ -1,4 +1,4 @@
-package = "protobuf"
+package = "protobuf-lua"
 version = "%VERSION%-0"
 source = {
     url = "git://github.com/djungelorm/protobuf-lua",


### PR DESCRIPTION
This patch fixes the module name to 'protobuf-lua' so it can be
submited as a new package to the Buildroot build system project.

Signed-off-by: Tiago Brusamarello tbrusa@gmail.com
