### PR TITLE
Support building on Windows

### DIFF
--- a/protobuf/pb.c
+++ b/protobuf/pb.c
@@ -28,6 +28,9 @@
 
 #if defined(_ALLBSD_SOURCE) || defined(__APPLE__)
 #include <machine/endian.h>
+#elif defined(_WIN32)
+#define __LITTLE_ENDIAN 1234
+#define __BYTE_ORDER __LITTLE_ENDIAN
 #else
 #include <endian.h>
 #endif


### PR DESCRIPTION
MSVC does not have the `endian.h` header. But, if we assume little-endian encoding for most Windows set-ups, the conversion functions from that header are not necessary.